### PR TITLE
Set origin just before drawing the canvas

### DIFF
--- a/nest/runner.lua
+++ b/nest/runner.lua
@@ -33,8 +33,6 @@ return function(windows)
             end
 
             if love.graphics then
-                love.graphics.origin()
-
                 for _, screen in ipairs(windows) do
                     love.graphics.setActiveScreen(screen:getName())
 
@@ -46,6 +44,7 @@ return function(windows)
                         end
                     end)
 
+                    love.graphics.origin()
                     screen:draw()
                 end
 


### PR DESCRIPTION
This prevents the canvas position from being affected when using a global transformations. Otherwise the canvas ends up going out of the visible area.